### PR TITLE
Build the book on all branches except master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+# Build, but do not deploy, the book on all branches except `master`.
+
+name: Build
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Install mdbook
+      run: |
+        mkdir mdbook
+        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.18/mdbook-v0.4.18-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -sSL https://github.com/tommilligan/mdbook-admonish/releases/download/v1.5.0/mdbook-admonish-v1.5.0-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.6/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -o linkcheck.zip
+        unzip linkcheck.zip -d ./mdbook
+        chmod u+x ./mdbook/mdbook-linkcheck
+        echo `pwd`/mdbook >> $GITHUB_PATH
+    - name: Build the book
+      run: |
+        # This assumes your book is in the root of your repository.
+        # Just add a `cd` here if you need to change to another directory.
+        mdbook build


### PR DESCRIPTION
This adds a new GitHub action that will build the book when new commits
are pushed to any branch except "master".

Fixes #10.