### PR TITLE
Add support for tabbed code blocks

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -9,7 +9,8 @@ title = "Git is my lab book"
 command = "mdbook-admonish"
 
 [output.html]
-additional-css = ["mdbook-admonish.css"]
+additional-css = ["mdbook-admonish.css", "tabbed-code-blocks.css"]
+additional-js = ["tabbed-code-blocks.js"]
 git-repository-url = "https://github.com/robmoss/git-is-my-lab-book"
 edit-url-template = "https://github.com/robmoss/git-is-my-lab-book/edit/master/{path}"
 

--- a/src/how-to-contribute.md
+++ b/src/how-to-contribute.md
@@ -30,3 +30,62 @@ You can suggest modifications and new content by:
 You can also edit any page by clicking the "Suggest an edit" button (<i class="fa fa-edit"></i>) in the top-right corner.
 This will start the process described above by forking the book repository.
 ```
+
+## Adding tabbed code blocks
+
+You can display multiple code blocks as a tabbed group by enclosing them in a `<div class="tabbed-blocks"> ... </div>` container.
+For example:
+
+~~~md
+<div class="tabbed-blocks">
+
+```python
+print("Hello world")
+```
+
+```R
+cat("Hello world\n")
+```
+
+```cpp
+#include <iostream>
+
+int main() {
+    std::cout << "Hello World";
+    return 0;
+}
+```
+
+```sh
+echo "Hello world"
+```
+
+</div>
+~~~
+
+produces:
+
+<div class="tabbed-blocks">
+
+```python
+print("Hello world")
+```
+
+```R
+cat("Hello world\n")
+```
+
+```cpp
+#include <iostream>
+
+int main() {
+    std::cout << "Hello World";
+    return 0;
+}
+```
+
+```sh
+echo "Hello world"
+```
+
+</div>

--- a/tabbed-code-blocks.css
+++ b/tabbed-code-blocks.css
@@ -1,0 +1,24 @@
+/* Implement tabbed code blocks for mdBook. */
+
+.tabbed-blocks ul.tab-bar {
+    padding: 0;
+    margin: 0;
+}
+
+.tabbed-blocks ul.tab-bar li {
+    display: inline-block;
+    min-width: 4em;
+    padding: 0.5em; 1em;
+    text-align: center;
+    user-select: none;
+}
+
+/* Use the background colour from mdbook-admonish info blocks. */
+.tabbed-blocks ul.tab-bar li.active {
+    background-color: rgba(0, 184, 212, 0.1);
+}
+
+/* Remove vertical space between tabs and code blocks. */
+.tabbed-blocks pre {
+    margin-top: 0;
+}

--- a/tabbed-code-blocks.css
+++ b/tabbed-code-blocks.css
@@ -13,9 +13,14 @@
     user-select: none;
 }
 
-/* Use the background colour from mdbook-admonish info blocks. */
+/* Use the background and border colours from mdbook-admonish info blocks. */
 .tabbed-blocks ul.tab-bar li.active {
     background-color: rgba(0, 184, 212, 0.1);
+    border-top: 4px solid #00b8d4;
+}
+
+.tabbed-blocks ul.tab-bar li {
+    border-top: 4px solid rgba(127, 127, 127, 0.5);
 }
 
 /* Remove vertical space between tabs and code blocks. */

--- a/tabbed-code-blocks.js
+++ b/tabbed-code-blocks.js
@@ -39,10 +39,16 @@ function getTabTextForCode(code_elt) {
     // Identify the language based on the code element's class.
     if (code_elt.classList.contains("language-python")) {
         return "Python";
+    } else if (code_elt.classList.contains("language-py")) {
+        return "Python";
     } else if (code_elt.classList.contains("language-R")) {
         return "R";
     } else if (code_elt.classList.contains("language-cpp")) {
         return "C++";
+    } else if (code_elt.classList.contains("language-sh")) {
+        return "Shell";
+    } else if (code_elt.classList.contains("language-text")) {
+        return "Text";
     } else {
         return "Unknown language";
     }

--- a/tabbed-code-blocks.js
+++ b/tabbed-code-blocks.js
@@ -1,0 +1,72 @@
+/* Implement tabbed code blocks for mdBook. */
+
+function addTabsToGroup(group) {
+    // Create the container for the tab buttons.
+    const tab_bar = document.createElement("ul");
+    tab_bar.className = "tab-bar";
+    group.prepend(tab_bar);
+
+    // Add a tab for each code block, and hide all but the first block.
+    const pre_elements = group.querySelectorAll("pre");
+    pre_elements.forEach((pre_elt, ix) => {
+        const tab_elt = addTabForCodeBlock(tab_bar, pre_elements, pre_elt);
+        if (ix > 0) {
+            pre_elt.style.display = "none";
+        } else {
+            tab_elt.classList.add("active");
+        }
+    });
+}
+
+function addTabForCodeBlock(tab_bar, pre_elts, pre_elt) {
+    // Find the code element, from which we can identify the language.
+    const code_elt = pre_elt.querySelector("code");
+    // Identify the code block language.
+    const tab_text = document.createTextNode(getTabTextForCode(code_elt));
+
+    // Create the button for this tab.
+    const tab_elt = document.createElement("li");
+    tab_elt.appendChild(tab_text);
+    tab_bar.appendChild(tab_elt);
+
+    // Add an event handler for switching between tabs.
+    addTabEventHandler(tab_elt, tab_bar, pre_elts, pre_elt);
+
+    return tab_elt;
+}
+
+function getTabTextForCode(code_elt) {
+    // Identify the language based on the code element's class.
+    if (code_elt.classList.contains("language-python")) {
+        return "Python";
+    } else if (code_elt.classList.contains("language-R")) {
+        return "R";
+    } else if (code_elt.classList.contains("language-cpp")) {
+        return "C++";
+    } else {
+        return "Unknown language";
+    }
+}
+
+function addTabEventHandler(tab_elt, tab_bar, pre_elts, pre_elt) {
+    tab_elt.addEventListener("click", () => {
+        // Hide all code blocks.
+        pre_elts.forEach((pre_elt) => {
+            pre_elt.style.display = "none";
+        });
+        // Show this code block.
+        pre_elt.style.display = "block";
+
+        // Mark this button as the active tab.
+        tab_bar.querySelectorAll("li").forEach((elt) => {
+            elt.classList.remove("active");
+        });
+        tab_elt.classList.add("active");
+    });
+}
+
+// Create a tab bar for each group of code blocks.
+window.addEventListener("DOMContentLoaded", (event) => {
+    const tab_groups = document.querySelectorAll("div.tabbed-blocks");
+    tab_groups.forEach(addTabsToGroup);
+});

--- a/tabbed-code-blocks.js
+++ b/tabbed-code-blocks.js
@@ -1,5 +1,30 @@
 /* Implement tabbed code blocks for mdBook. */
 
+(function() {
+"use strict";
+
+// The CSS selector used to identify groups of tabbed code blocks.
+const blocks_selector = "div.tabbed-blocks";
+
+// The CSS class used to identify the active tab.
+const class_active = "active";
+
+// NOTE: the order in which we define the names is important, because we
+// iterate over the names in the *insertion order*.
+const tab_names = new Map();
+tab_names.set("language-python", "Python");
+tab_names.set("language-py", "Python");
+tab_names.set("language-R", "R");
+tab_names.set("language-cpp", "C++");
+tab_names.set("language-sh", "Shell");
+tab_names.set("language-shell", "Shell");
+tab_names.set("language-md", "Markdown");
+tab_names.set("language-text", "Text");
+tab_names.set("language-diff", "Diff");
+
+// The tab name to use when none of the above names apply.
+const default_tab_name = "Unknown";
+
 function addTabsToGroup(group) {
     // Create the container for the tab buttons.
     const tab_bar = document.createElement("ul");
@@ -13,7 +38,7 @@ function addTabsToGroup(group) {
         if (ix > 0) {
             pre_elt.style.display = "none";
         } else {
-            tab_elt.classList.add("active");
+            tab_elt.classList.add(class_active);
         }
     });
 }
@@ -37,21 +62,12 @@ function addTabForCodeBlock(tab_bar, pre_elts, pre_elt) {
 
 function getTabTextForCode(code_elt) {
     // Identify the language based on the code element's class.
-    if (code_elt.classList.contains("language-python")) {
-        return "Python";
-    } else if (code_elt.classList.contains("language-py")) {
-        return "Python";
-    } else if (code_elt.classList.contains("language-R")) {
-        return "R";
-    } else if (code_elt.classList.contains("language-cpp")) {
-        return "C++";
-    } else if (code_elt.classList.contains("language-sh")) {
-        return "Shell";
-    } else if (code_elt.classList.contains("language-text")) {
-        return "Text";
-    } else {
-        return "Unknown language";
+    for (const [class_name, tab_text] of tab_names) {
+        if (code_elt.classList.contains(class_name)) {
+            return tab_text;
+        }
     }
+    return default_tab_name;
 }
 
 function addTabEventHandler(tab_elt, tab_bar, pre_elts, pre_elt) {
@@ -65,14 +81,16 @@ function addTabEventHandler(tab_elt, tab_bar, pre_elts, pre_elt) {
 
         // Mark this button as the active tab.
         tab_bar.querySelectorAll("li").forEach((elt) => {
-            elt.classList.remove("active");
+            elt.classList.remove(class_active);
         });
-        tab_elt.classList.add("active");
+        tab_elt.classList.add(class_active);
     });
 }
 
 // Create a tab bar for each group of code blocks.
 window.addEventListener("DOMContentLoaded", (event) => {
-    const tab_groups = document.querySelectorAll("div.tabbed-blocks");
+    const tab_groups = document.querySelectorAll(blocks_selector);
     tab_groups.forEach(addTabsToGroup);
 });
+
+})();


### PR DESCRIPTION
I've written some basic JavaScript and CSS so that we can wrap a series of code blocks with a single `div` element.

If JavaScript is disabled, this has no effect and all of the code blocks are shown as per usual.

I think this is sufficient for our needs, what do you think Eamon?

Here is an example of wrapping multiple code blocks:

~~~md
<div class="tabbed-blocks">

```python
import datetime

print(datetime.datetime.now())
```

```R
print(Sys.time())
```

```cpp
#include <iostream>

int main() {
    std::cout << "Hello World!";
    return 0;
}
```

</div>
~~~ 

and the result looks like:

![tab-python](https://user-images.githubusercontent.com/5481883/170810148-5b0a2a31-8d43-45fa-8c58-51d1abc182a3.png)

![tab-r](https://user-images.githubusercontent.com/5481883/170810154-e011fbc8-e089-42b6-9195-addd12982667.png)

![tab-cpp](https://user-images.githubusercontent.com/5481883/170810157-eda71276-6b0a-422e-90c5-202c07d33824.png)

By default, it will show the **first code block**.

Fixes #12.