### PR TITLE
Update installation and building instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         mkdir mdbook
         curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.18/mdbook-v0.4.18-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-        curl -sSL https://github.com/tommilligan/mdbook-admonish/releases/download/v1.5.0/mdbook-admonish-v1.5.0-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -sSL https://github.com/tommilligan/mdbook-admonish/releases/download/v1.6.0/mdbook-admonish-v1.6.0-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.6/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -o linkcheck.zip
         unzip linkcheck.zip -d ./mdbook
         chmod u+x ./mdbook/mdbook-linkcheck

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         mkdir mdbook
         curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.18/mdbook-v0.4.18-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-        curl -sSL https://github.com/tommilligan/mdbook-admonish/releases/download/v1.5.0/mdbook-admonish-v1.5.0-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -sSL https://github.com/tommilligan/mdbook-admonish/releases/download/v1.6.0/mdbook-admonish-v1.6.0-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.6/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -o linkcheck.zip
         unzip linkcheck.zip -d ./mdbook
         chmod u+x ./mdbook/mdbook-linkcheck

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 Inter
 To build this book, you must have the following programs installed:
 
 - [mdBook 0.4.18](https://github.com/rust-lang/mdBook/releases/tag/v0.4.18)
-- [mdbook-admonish 1.5.0](https://github.com/tommilligan/mdbook-admonish/releases/tag/v1.5.0)
+- [mdbook-admonish 1.6.0](https://github.com/tommilligan/mdbook-admonish/releases/tag/v1.6.0)
 - [mdbook-linkcheck 0.7.6](https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/tag/v0.7.6)
 
 ## Building the book

--- a/README.md
+++ b/README.md
@@ -13,15 +13,23 @@ You can [view this book online][book].
 
 This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License][license].
 
+## Requirements
+
+To build this book, you must have the following programs installed:
+
+- [mdBook 0.4.18](https://github.com/rust-lang/mdBook/releases/tag/v0.4.18)
+- [mdbook-admonish 1.5.0](https://github.com/tommilligan/mdbook-admonish/releases/tag/v1.5.0)
+- [mdbook-linkcheck 0.7.6](https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/tag/v0.7.6)
+
 ## Building the book
 
-You can build this book by installing [mdBook](https://rust-lang.github.io/mdBook/), [mdbook-admonish](https://github.com/tommilligan/mdbook-admonish/), and [mdbook-linkcheck](https://github.com/Michael-F-Bryan/mdbook-linkcheck), and running the following command in this directory:
+You can view this book in your browser by running the following command in this directory:
 
 ```shell
-mdbook build
+mdbook serve --open
 ```
 
-You can then open `book/html/index.html` in your browser.
+This will automatically rebuild the book whenever you edit the contents.
 
 [book]: https://robmoss.github.io/git-is-my-lab-book/
 [license]: http://creativecommons.org/licenses/by-sa/4.0/

--- a/book.toml
+++ b/book.toml
@@ -7,6 +7,7 @@ title = "Git is my lab book"
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
+assets_version = "1.0.0" # do not edit: managed by `mdbook-admonish install`
 
 [output.html]
 additional-css = ["mdbook-admonish.css"]

--- a/mdbook-admonish.css
+++ b/mdbook-admonish.css
@@ -56,20 +56,24 @@ html :is(.admonition) > :last-child {
   margin-bottom: 1.2rem;
 }
 
+a.admonition-anchor-link:link, a.admonition-anchor-link:visited {
+  color: var(--fg);
+}
+a.admonition-anchor-link:link:hover, a.admonition-anchor-link:visited:hover {
+  text-decoration: none;
+}
+
 :is(.admonition-title, summary) {
   position: relative;
   margin-block: 0;
   margin-inline: -1.6rem -1.2rem;
   padding-block: 0.8rem;
-  padding-inline: 4rem 1.2rem;
+  padding-inline: 4.4rem 1.2rem;
   font-weight: 700;
   background-color: rgba(68, 138, 255, 0.1);
-  border: 0 solid #448aff;
-  border-inline-start-width: 0.4rem;
-  border-start-start-radius: 0.2rem;
   display: flex;
 }
-:is(.admonition-title, summary) > p {
+:is(.admonition-title, summary) p {
   margin: 0;
 }
 html :is(.admonition-title, summary):last-child {
@@ -78,7 +82,7 @@ html :is(.admonition-title, summary):last-child {
 :is(.admonition-title, summary)::before {
   position: absolute;
   top: 0.625em;
-  inset-inline-start: 1.2rem;
+  inset-inline-start: 1.6rem;
   width: 2rem;
   height: 2rem;
   background-color: #448aff;
@@ -97,7 +101,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.note) > :is(.admonition-title, summary) {
   background-color: rgba(68, 138, 255, 0.1);
-  border-color: #448aff;
 }
 :is(.note) > :is(.admonition-title, summary)::before {
   background-color: #448aff;
@@ -115,7 +118,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary) {
   background-color: rgba(0, 176, 255, 0.1);
-  border-color: #00b0ff;
 }
 :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary)::before {
   background-color: #00b0ff;
@@ -133,7 +135,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.info, .todo) > :is(.admonition-title, summary) {
   background-color: rgba(0, 184, 212, 0.1);
-  border-color: #00b8d4;
 }
 :is(.info, .todo) > :is(.admonition-title, summary)::before {
   background-color: #00b8d4;
@@ -151,7 +152,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.tip, .hint, .important) > :is(.admonition-title, summary) {
   background-color: rgba(0, 191, 165, 0.1);
-  border-color: #00bfa5;
 }
 :is(.tip, .hint, .important) > :is(.admonition-title, summary)::before {
   background-color: #00bfa5;
@@ -169,7 +169,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.success, .check, .done) > :is(.admonition-title, summary) {
   background-color: rgba(0, 200, 83, 0.1);
-  border-color: #00c853;
 }
 :is(.success, .check, .done) > :is(.admonition-title, summary)::before {
   background-color: #00c853;
@@ -187,7 +186,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.question, .help, .faq) > :is(.admonition-title, summary) {
   background-color: rgba(100, 221, 23, 0.1);
-  border-color: #64dd17;
 }
 :is(.question, .help, .faq) > :is(.admonition-title, summary)::before {
   background-color: #64dd17;
@@ -205,7 +203,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.warning, .caution, .attention) > :is(.admonition-title, summary) {
   background-color: rgba(255, 145, 0, 0.1);
-  border-color: #ff9100;
 }
 :is(.warning, .caution, .attention) > :is(.admonition-title, summary)::before {
   background-color: #ff9100;
@@ -223,7 +220,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.failure, .fail, .missing) > :is(.admonition-title, summary) {
   background-color: rgba(255, 82, 82, 0.1);
-  border-color: #ff5252;
 }
 :is(.failure, .fail, .missing) > :is(.admonition-title, summary)::before {
   background-color: #ff5252;
@@ -241,7 +237,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.danger, .error) > :is(.admonition-title, summary) {
   background-color: rgba(255, 23, 68, 0.1);
-  border-color: #ff1744;
 }
 :is(.danger, .error) > :is(.admonition-title, summary)::before {
   background-color: #ff1744;
@@ -259,7 +254,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.bug) > :is(.admonition-title, summary) {
   background-color: rgba(245, 0, 87, 0.1);
-  border-color: #f50057;
 }
 :is(.bug) > :is(.admonition-title, summary)::before {
   background-color: #f50057;
@@ -277,7 +271,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.example) > :is(.admonition-title, summary) {
   background-color: rgba(124, 77, 255, 0.1);
-  border-color: #7c4dff;
 }
 :is(.example) > :is(.admonition-title, summary)::before {
   background-color: #7c4dff;
@@ -295,7 +288,6 @@ html :is(.admonition-title, summary):last-child {
 
 :is(.quote, .cite) > :is(.admonition-title, summary) {
   background-color: rgba(158, 158, 158, 0.1);
-  border-color: #9e9e9e;
 }
 :is(.quote, .cite) > :is(.admonition-title, summary)::before {
   background-color: #9e9e9e;
@@ -317,5 +309,8 @@ html :is(.admonition-title, summary):last-child {
 
 .rust :is(.admonition) {
   background-color: var(--sidebar-bg);
+  color: var(--sidebar-fg);
+}
+.rust .admonition-anchor-link:link, .rust .admonition-anchor-link:visited {
   color: var(--sidebar-fg);
 }


### PR DESCRIPTION
This adds links to the specific releases of each required program (mdBook, mdbook-admonish, and mdbook-linkcheck) in `README.md`, from which the user can download the appropriate binaries for their operating system.

This also updates mdbook-admonish from 1.5.0 to 1.6.0, which fixes a visual bug in Firefox and allows us to link to individual admonish blocks.