### PR TITLE
Define mdbook installation steps in a Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,8 @@ jobs:
         fetch-depth: 0
     - name: Install mdbook
       run: |
-        mkdir mdbook
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.18/mdbook-v0.4.18-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-        curl -sSL https://github.com/tommilligan/mdbook-admonish/releases/download/v1.6.0/mdbook-admonish-v1.6.0-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-        curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.6/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -o linkcheck.zip
-        unzip linkcheck.zip -d ./mdbook
-        chmod u+x ./mdbook/mdbook-linkcheck
-        echo `pwd`/mdbook >> $GITHUB_PATH
+        make install
+        echo $(pwd)/mdbook >> $GITHUB_PATH
     - name: Build the book
       run: |
-        # This assumes your book is in the root of your repository.
-        # Just add a `cd` here if you need to change to another directory.
         mdbook build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,17 +16,10 @@ jobs:
         fetch-depth: 0
     - name: Install mdbook
       run: |
-        mkdir mdbook
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.18/mdbook-v0.4.18-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-        curl -sSL https://github.com/tommilligan/mdbook-admonish/releases/download/v1.6.0/mdbook-admonish-v1.6.0-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-        curl -sSL https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.6/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -o linkcheck.zip
-        unzip linkcheck.zip -d ./mdbook
-        chmod u+x ./mdbook/mdbook-linkcheck
-        echo `pwd`/mdbook >> $GITHUB_PATH
+        make install
+        echo $(pwd)/mdbook >> $GITHUB_PATH
     - name: Deploy GitHub Pages
       run: |
-        # This assumes your book is in the root of your repository.
-        # Just add a `cd` here if you need to change to another directory.
         mdbook build
         git worktree add -b gh-pages gh-pages
         git config user.name "Deploy from CI"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,73 @@
+#
+# Define recipes for installing mdbook and other required tools.
+#
+
+# The required version of each tool used to build the book.
+MDBOOK_VERSION := 0.4.18
+ADMONISH_VERSION := 1.6.0
+LINKCHECK_VERSION := 0.7.6
+
+# Where to install mdbook and other required tools.
+TOOLS_DIR := $(CURDIR)/mdbook
+
+# The full path to each tool.
+MDBOOK_CMD := $(TOOLS_DIR)/mdbook
+ADMONISH_CMD := $(TOOLS_DIR)/mdbook-admonish
+LINKCHECK_CMD := $(TOOLS_DIR)/mdbook-linkcheck
+
+#
+# Show instructions for using this Makefile.
+#
+help:
+	@echo ''
+	@echo 'USAGE: make <target>'
+	@echo ''
+	@echo 'TARGETS:'
+	@echo ''
+	@echo '    install:  Install mdbook and other required tools'
+	@echo '    help:     Display this help message'
+	@echo ''
+
+#
+# Install mdbook and other required tools.
+#
+install: $(MDBOOK_CMD) $(ADMONISH_CMD) $(LINKCHECK_CMD)
+
+#
+# Ensure that the tools directory exists.
+#
+$(TOOLS_DIR):
+	mkdir -p $(TOOLS_DIR)
+
+#
+# Ensure that mdbook is installed.
+#
+$(MDBOOK_CMD): | $(TOOLS_DIR)
+	curl -sSL $(MDBOOK_TGZ) | tar -xz --directory=$(TOOLS_DIR)
+
+#
+# Ensure that mdbook-admonish is installed.
+#
+$(ADMONISH_CMD): | $(TOOLS_DIR)
+	curl -sSL $(ADMONISH_TGZ) | tar -xz --directory=$(TOOLS_DIR)
+
+#
+# Ensure that mdbook-linkcheck is installed.
+#
+$(LINKCHECK_CMD): | $(TOOLS_DIR)
+	curl -sSL $(LINKCHECK_ZIP) -o linkcheck.zip
+	unzip -d $(TOOLS_DIR) -o -q linkcheck.zip
+	chmod u+x "$(TOOLS_DIR)/mdbook-linkcheck"
+	rm linkcheck.zip
+
+#
+# Identify targets that are not file names.
+#
+.PHONY: help install
+
+
+
+# The URLs from which each tool can be downloaded.
+MDBOOK_TGZ := "https://github.com/rust-lang/mdBook/releases/download/v$(MDBOOK_VERSION)/mdbook-v$(MDBOOK_VERSION)-x86_64-unknown-linux-gnu.tar.gz"
+ADMONISH_TGZ := "https://github.com/tommilligan/mdbook-admonish/releases/download/v$(ADMONISH_VERSION)/mdbook-admonish-v$(ADMONISH_VERSION)-x86_64-unknown-linux-gnu.tar.gz"
+LINKCHECK_ZIP := "https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v$(LINKCHECK_VERSION)/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip"


### PR DESCRIPTION
This avoids duplicating each step in the build and deploy actions.