### PR TITLE
Retain the gh-pages branch history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,4 @@
-# As per the mdBook wiki:
-# https://github.com/rust-lang/mdBook/wiki/Automated-Deployment%3A-GitHub-Actions
+# Build and publish the `master` branch to GitHub Pages.
 
 name: Deploy
 on:
@@ -18,17 +17,11 @@ jobs:
       run: |
         make install
         echo $(pwd)/mdbook >> $GITHUB_PATH
-    - name: Deploy GitHub Pages
+    - name: Build the book
       run: |
         mdbook build
-        git worktree add -b gh-pages gh-pages
-        git config user.name "Deploy from CI"
-        git config user.email ""
-        cd gh-pages
-        # Delete the ref to avoid keeping history.
-        git update-ref -d refs/heads/gh-pages
-        rm -rf *
-        mv ../book/html/* .
-        git add .
-        git commit -m "Deploy $GITHUB_SHA to gh-pages"
-        git push --force --set-upstream origin gh-pages
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./book/html


### PR DESCRIPTION
Pushing an innocuous commit (56682a0) appeared to reset the repository custom domain setting, making the book inaccessible. I don't know what caused this issue, but we previously deleted the existing gh-pages branch every time the book was updated. This commit makes the deploy action retain the branch history, and hopefully the custom domain will not be affected by future commits.