### PR TITLE
Add online previews for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 # Build, but do not deploy, the book on all branches except `master`.
 
 name: Build
+
 on:
   push:
     branches-ignore:
@@ -10,13 +11,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install mdbook
-      run: |
-        make install
-        echo $(pwd)/mdbook >> $GITHUB_PATH
-    - name: Build the book
-      run: |
-        mdbook build
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install mdbook
+        run: |
+          make install
+          echo $(pwd)/mdbook >> $GITHUB_PATH
+
+      - name: Build the book
+        run: |
+          mdbook build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
-# As per the mdBook wiki:
-# https://github.com/rust-lang/mdBook/wiki/Automated-Deployment%3A-GitHub-Actions
+# Build the `master` branch and deploy.
 
 name: Deploy
+
 on:
   push:
     branches:
@@ -11,24 +11,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install mdbook
-      run: |
-        make install
-        echo $(pwd)/mdbook >> $GITHUB_PATH
-    - name: Deploy GitHub Pages
-      run: |
-        mdbook build
-        git worktree add -b gh-pages gh-pages
-        git config user.name "Deploy from CI"
-        git config user.email ""
-        cd gh-pages
-        # Delete the ref to avoid keeping history.
-        git update-ref -d refs/heads/gh-pages
-        rm -rf *
-        mv ../book/html/* .
-        git add .
-        git commit -m "Deploy $GITHUB_SHA to gh-pages"
-        git push --force --set-upstream origin gh-pages
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install mdbook
+        run: |
+          make install
+          echo $(pwd)/mdbook >> $GITHUB_PATH
+
+      - name: Build the book
+        run: |
+          mdbook build
+
+      - name: Deploy GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: book/html

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,9 +9,6 @@ on:
       - reopened
       - synchronize
       - closed
-    branches-ignore:
-      - master
-      - gh-pages
 
 concurrency: preview-${{ github.ref }}
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,41 @@
+# Build pull requests and deploy.
+
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+    branches-ignore:
+      - master
+      - gh-pages
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install mdbook
+        run: |
+          make install
+          echo $(pwd)/mdbook >> $GITHUB_PATH
+
+      - name: Build the book
+        run: |
+          mdbook build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          force: false
+          clean-exclude: pr-preview/
+          source-dir: book/html

--- a/src/collaborating/continuous-integration.md
+++ b/src/collaborating/continuous-integration.md
@@ -10,4 +10,5 @@ Because the central repository is hosted on GitHub, we use [GitHub Actions](http
 You can view the update action for this book [here](https://github.com/robmoss/git-is-my-lab-book/blob/master/.github/workflows/deploy.yml).
 
 We also use CI to publish each pull request, so that contributions can be previewed during the review process.
+We added this feature in [this pull request](https://github.com/robmoss/git-is-my-lab-book/pull/26).
 ```

--- a/src/collaborating/continuous-integration.md
+++ b/src/collaborating/continuous-integration.md
@@ -8,4 +8,6 @@ This book is an example of Continuous Integration: every time a commit is pushed
 
 Because the central repository is hosted on GitHub, we use [GitHub Actions](https://docs.github.com/en/actions/quickstart). Note that this is a GitHub-specific CI system.
 You can view the update action for this book [here](https://github.com/robmoss/git-is-my-lab-book/blob/master/.github/workflows/deploy.yml).
+
+We also use CI to publish each pull request, so that contributions can be previewed during the review process.
 ```


### PR DESCRIPTION
This changes how the main book is deployed, so that the gh-pages branch is not overwritten every time the book is updated.