### PR TITLE
Fix/tabbed rust code blocks

### DIFF
--- a/src/how-to-contribute.md
+++ b/src/how-to-contribute.md
@@ -67,6 +67,12 @@ int main() {
 echo "Hello world"
 ```
 
+```rust
+fn main() {
+    println!("Hello World");
+}
+```
+
 </div>
 ~~~
 
@@ -93,6 +99,12 @@ int main() {
 
 ```sh
 echo "Hello world"
+```
+
+```rust
+fn main() {
+    println!("Hello World");
+}
 ```
 
 </div>

--- a/tabbed-code-blocks.js
+++ b/tabbed-code-blocks.js
@@ -33,7 +33,8 @@ function addTabsToGroup(group) {
     group.prepend(tab_bar);
 
     // Add a tab for each code block, and hide all but the first block.
-    const pre_elements = group.querySelectorAll("pre");
+    // Note the use of the '>' combinator to only select top-level blocks.
+    const pre_elements = group.querySelectorAll(":scope > pre");
     pre_elements.forEach((pre_elt, ix) => {
         const tab_elt = addTabForCodeBlock(tab_bar, pre_elements, pre_elt);
         if (ix > 0) {

--- a/tabbed-code-blocks.js
+++ b/tabbed-code-blocks.js
@@ -15,6 +15,7 @@ const tab_names = new Map();
 tab_names.set("language-python", "Python");
 tab_names.set("language-py", "Python");
 tab_names.set("language-R", "R");
+tab_names.set("language-rust", "Rust");
 tab_names.set("language-cpp", "C++");
 tab_names.set("language-sh", "Shell");
 tab_names.set("language-shell", "Shell");


### PR DESCRIPTION
Fixes #27 by adding support for tabbed Rust code blocks, and only converting top-level `<pre>` elements into tabs.