### PR TITLE
Improve pull requests: additional instructions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,7 +30,11 @@ jobs:
         run: |
           mdbook build
 
+      # NOTE: we can only deploy PR previews from the original repository.
+      # This action fails when the PR originates from a forked repository;
+      # see https://github.com/rossjrw/pr-preview-action/issues/3 for details.
       - name: Deploy preview
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: rossjrw/pr-preview-action@v1
         with:
           force: false

--- a/src/how-to-contribute.md
+++ b/src/how-to-contribute.md
@@ -38,6 +38,10 @@ Also check that your text editor **removes trailing whitespace**.
 This ensures that each commit will contain only the modified sentences, and makes it easier to inspect the repository history.
 ```
 
+```admonish tip
+When you add a new page, you must also **add the page to the table of contents** in [`src/SUMMARY.md`](https://github.com/robmoss/git-is-my-lab-book/edit/master/src/SUMMARY.md).
+```
+
 ## Adding tabbed code blocks
 
 You can display multiple code blocks as a tabbed group by enclosing them in a `<div class="tabbed-blocks"> ... </div>` container.


### PR DESCRIPTION
We discovered with #31 that we cannot publish PR previews from forked repositories, and we also need to highlight that new files must be added to the table of contents in `src/SUMMARY.md`.