### PR TITLE
Use three-way diffs for merge conflicts

### DIFF
--- a/src/using-git/first-time-git-setup.md
+++ b/src/using-git/first-time-git-setup.md
@@ -38,6 +38,14 @@ Once you've installed Git, you should define some important settings before you 
 
    ![Merged branch](../version-control/branch-3.png)
 
+5. Adjust how Git shows merge conflicts:
+
+   ```sh
+   git config --global merge.conflictstyle diff3
+   ```
+
+   This will be useful when we look at [how to use branches](how-to-use-branches.md) and [how to resolve merge conflicts](how-to-resolve-merge-conflicts.md).
+
 ```admonish info
 If you use Windows, there are tools that can [improve your Git experience in PowerShell](https://git-scm.com/book/en/v2/Appendix-A%3A-Git-in-Other-Environments-Git-in-PowerShell).
 

--- a/src/using-git/first-time-git-setup.md
+++ b/src/using-git/first-time-git-setup.md
@@ -2,6 +2,12 @@
 
 Once you've installed Git, you should define some important settings before you starting using Git.
 
+```admonish info
+We assume that you will want to set the git configuration for all repositories owned by your user.
+Therefore, we use the `--global` flag.
+Configuration files can be set for a single repository or the whole computer by replacing `--global` with `--local` or `--system` respectively.
+```
+
 1. Define your user name and email address.
    These details are included in **every commit that you create**.
 

--- a/src/using-git/how-to-resolve-merge-conflicts.md
+++ b/src/using-git/how-to-resolve-merge-conflicts.md
@@ -52,6 +52,28 @@ Note that this two-day diff shows:
 
 Each conflict is surrounded by `<<<<<<<` and `>>>>>>>` markers, and the conflicting changes are separated by a `=======` marker.
 
+If we instruct Git to use a three-way diff (see [first-time Git setup](first-time-git-setup.md)), the conflict will be reported slightly differently:
+
+```diff
+diff --cc test.txt
+index 18712c4,bc576a6..0000000
+--- a/test.txt
++++ b/test.txt
+@@@ -1,3 -1,3 +1,7 @@@
+  First line
+++<<<<<<< ours
+ +A different second line
+++||||||| base
+++Second line
+++=======
++ My new second line
+++>>>>>>> theirs
+  Third line
+```
+
+In addition to showing "our" changes and "their changes", this three-way diff also shows the **original lines**, between the `|||||||` and `=======` markers.
+This extra information can help you decide how to best resolve the conflict.
+
 ## Resolving the conflicts
 
 We can edit `test.txt` to reconcile these changes, and the commit our fix.


### PR DESCRIPTION
As part of the initial setup instructions, we now set the merge-conflict style to 'diff3', which also shows the original lines. This extra information can help to decide how to best resolve a conflict.

In the first example conflict, it changes the diff from:

```diff
diff --cc test.txt
index 18712c4,bc576a6..0000000
--- a/test.txt
+++ b/test.txt
@@@ -1,3 -1,3 +1,7 @@@
  First line
++<<<<<<< ours
 +A different second line
++=======
+ My new second line
++>>>>>>> theirs
  Third line
```

to:

```diff
diff --cc test.txt
index 18712c4,bc576a6..0000000
--- a/test.txt
+++ b/test.txt
@@@ -1,3 -1,3 +1,7 @@@
  First line
++<<<<<<< ours
 +A different second line
++||||||| base
++Second line
++=======
+ My new second line
++>>>>>>> theirs
  Third line
```
