### PR TITLE
Add branch names to "git push -u remote" commands

### DIFF
--- a/docs/collaborating/sharing-a-branch.md
+++ b/docs/collaborating/sharing-a-branch.md
@@ -20,7 +20,7 @@ Remember that you can merge commits from their branch into your own branches at 
 2. Push this branch to your remote repository:
 
     ```sh
-    git push -u origin
+    git push -u origin collab/jamie
     ```
 
 3. Your collaborator can then make a local copy of this branch:

--- a/docs/using-git/how-to-use-branches.md
+++ b/docs/using-git/how-to-use-branches.md
@@ -35,7 +35,7 @@ git checkout -b my-new-branch my-other-branch  # From an existing branch
 You can then create a corresponding **upstream branch** in your remote repository (in this example, called "origin") by running:
 
 ```sh
-git push -u origin
+git push -u origin my-new-branch
 ```
 
 ## Working on a remote branch

--- a/docs/using-git/pushing-and-pulling-commits.md
+++ b/docs/using-git/pushing-and-pulling-commits.md
@@ -29,7 +29,14 @@ This requires that you have **created at least one commit** in your local reposi
 Once you have at least one commit in your local repository, you can create a corresponding **upstream branch** in the remote repository with the following command:
 
 ```sh
-git push -u origin
+git push -u origin <branch-name>
+```
+
+The default branch will probably be called `"main"` or `"master"`, depending on your [Git settings](first-time-git-setup.md).
+You can identify the branch name by running:
+
+```sh
+git branch
 ```
 
 !!! note
@@ -50,7 +57,7 @@ and pull commits by running:
 git pull
 ```
 
-without having to specify the remote repository.
+without having to specify the remote repository or branch name.
 
 ## Forcing updates to a remote repository
 


### PR DESCRIPTION
The default setting for `push.default` requires the user to configure an upstream branch with the same name as the local branch in order for `git push -u remote` to push the local branch upstream.

Fixes #62.

@EamonConway I've updated all relevant instances of `git push`. Please double-check the modified text and commands :)