### PR TITLE
Explain how to contribute to the orientation guide

### DIFF
--- a/docs/orientation/README.md
+++ b/docs/orientation/README.md
@@ -5,11 +5,25 @@ There was broad interest in having a checklist, and example workflows for people
 
 !!! info "How to contribute"
 
-    If you want to suggest a topic, or provide feedback about existing content, please [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=&body=Please enter a short, descriptive title (above) and explain your idea here).
+    To **suggest a new topic**:
 
-    If you to contribute content, please fork [the repository](https://github.com/robmoss/git-is-my-lab-book), add your contributions, and create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+    * Use the search box (top of the page) and check if the topic already exists;
 
-    See our [How to contribute](../how-to-contribute.md) page for more details, and [current orientation guide issues](https://github.com/robmoss/git-is-my-lab-book/issues?q=is%3Aissue+is%3Aopen+label%3Aorientation).
+    * If the topic does not exist, [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=New Topic:&body=Please enter a short, descriptive title (above) and explain your idea here).
+
+    To **provide feedback about existing content**:
+
+    * If the topic does not exist, [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=Feedback:&body=Please enter a short, descriptive title (above) and provide your feedback here).
+
+    To **contribute new content**:
+
+    * Use the search box (top of the page) and check if similar content already exists;
+
+    * If there is no similar content, please fork [the repository](https://github.com/robmoss/git-is-my-lab-book), add your contributions, and create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+
+    * See our [How to contribute](../how-to-contribute.md) page for more details, such as formatting guidelines.
+
+    Current issues for the orientation guide are [listed here](https://github.com/robmoss/git-is-my-lab-book/issues?q=is%3Aissue+is%3Aopen+label%3Aorientation).
 
 Suggested topics included:
 

--- a/docs/orientation/README.md
+++ b/docs/orientation/README.md
@@ -3,6 +3,12 @@
 One of [our goals for 2024](../community/meetings/2024-02-19.md#orientation-materials) is to develop orientation materials for new students, postdocs, etc.
 There was broad interest in having a checklist, and example workflows for people to follow — particularly for projects that involve some form of code "hand over", to ensure that the recipients experience few problems in running the code themselves.
 
+!!! info "How to contribute"
+
+    If you want to suggest a topic, or provide feedback about existing content, please [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=&body=Please enter a short, descriptive title (above) and explain your idea here).
+
+    If you to contribute content, please fork [the repository](https://github.com/robmoss/git-is-my-lab-book), add your contributions, and create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+
 Suggested topics included:
 
 - How to set up common tools on your laptop (e.g., Python and R);

--- a/docs/orientation/README.md
+++ b/docs/orientation/README.md
@@ -9,11 +9,11 @@ There was broad interest in having a checklist, and example workflows for people
 
     * Use the search box (top of the page) and check if the topic already exists;
 
-    * If the topic does not exist, [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=New Topic:&body=Please enter a short, descriptive title (above) and explain your idea here).
+    * If the topic does not exist, submit a ["New Topic" issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=New Topic:&body=Please enter a short, descriptive title (above) and explain your idea here).
 
-    To **suggest a useful resource**: [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=Useful Resource:&body=Please enter a short, descriptive title (above) and include a link to the resource here).
+    To **suggest a useful resource**: submit a ["Useful Resource" issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=Useful Resource:&body=Please enter a short, descriptive title (above) and include a link to the resource here).
 
-    To **provide feedback about existing content**: [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=Feedback:&body=Please enter a short, descriptive title (above) and provide your feedback here).
+    To **provide feedback about existing content**: submit a ["Feedback" issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=Feedback:&body=Please enter a short, descriptive title (above) and provide your feedback here).
 
     To **contribute new content**:
 

--- a/docs/orientation/README.md
+++ b/docs/orientation/README.md
@@ -19,7 +19,7 @@ There was broad interest in having a checklist, and example workflows for people
 
     * Use the search box (top of the page) and check if similar content already exists;
 
-    * If there is no similar content, please fork [the repository](https://github.com/robmoss/git-is-my-lab-book), add your contributions, and create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+    * If there is no similar content, please [create a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks) of [this repository](https://github.com/robmoss/git-is-my-lab-book), add your contributions, and create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
     * See our [How to contribute](../how-to-contribute.md) page for more details, such as formatting guidelines.
 

--- a/docs/orientation/README.md
+++ b/docs/orientation/README.md
@@ -11,9 +11,9 @@ There was broad interest in having a checklist, and example workflows for people
 
     * If the topic does not exist, [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=New Topic:&body=Please enter a short, descriptive title (above) and explain your idea here).
 
-    To **provide feedback about existing content**:
+    To **suggest a useful resource**: [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=Useful Resource:&body=Please enter a short, descriptive title (above) and include a link to the resource here).
 
-    * If the topic does not exist, [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=Feedback:&body=Please enter a short, descriptive title (above) and provide your feedback here).
+    To **provide feedback about existing content**: [submit an issue](https://github.com/robmoss/git-is-my-lab-book/issues/new?labels=orientation&title=Feedback:&body=Please enter a short, descriptive title (above) and provide your feedback here).
 
     To **contribute new content**:
 

--- a/docs/orientation/README.md
+++ b/docs/orientation/README.md
@@ -9,7 +9,7 @@ There was broad interest in having a checklist, and example workflows for people
 
     If you to contribute content, please fork [the repository](https://github.com/robmoss/git-is-my-lab-book), add your contributions, and create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
-    See our [How to contribute](../how-to-contribute.md) page for more details.
+    See our [How to contribute](../how-to-contribute.md) page for more details, and [current orientation guide issues](https://github.com/robmoss/git-is-my-lab-book/issues?q=is%3Aissue+is%3Aopen+label%3Aorientation).
 
 Suggested topics included:
 

--- a/docs/orientation/README.md
+++ b/docs/orientation/README.md
@@ -9,6 +9,8 @@ There was broad interest in having a checklist, and example workflows for people
 
     If you to contribute content, please fork [the repository](https://github.com/robmoss/git-is-my-lab-book), add your contributions, and create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
+    See our [How to contribute](../how-to-contribute.md) page for more details.
+
 Suggested topics included:
 
 - How to set up common tools on your laptop (e.g., Python and R);


### PR DESCRIPTION
This adds an admonition to the start of the Orientation Guide, which explains how to suggest topics (create issues) and add content (via pull requests).